### PR TITLE
feat: use ReactiveUI and display GridView of (dummy) git commits

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.8" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.8" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.8" />
   </ItemGroup>
 
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="11.2.8" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.8" />
     <PackageVersion Include="Avalonia.ReactiveUI" Version="11.2.8" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.2.8" />
   </ItemGroup>
 
 

--- a/GitRise/App.axaml
+++ b/GitRise/App.axaml
@@ -6,5 +6,6 @@
 
     <Application.Styles>
         <FluentTheme />
+        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
     </Application.Styles>
 </Application>

--- a/GitRise/App.axaml.cs
+++ b/GitRise/App.axaml.cs
@@ -71,6 +71,7 @@ public partial class App : Application
         hostBuilder.Logging.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace); //< set minimum level to trace in Debug
 
         //< below: register services to be available in Host
+        hostBuilder.Services.AddTransient<MainWindowViewModel>();
         hostBuilder.Services.AddTransient<MainWindow>();
 
         //< finally: return

--- a/GitRise/GitRise.csproj
+++ b/GitRise/GitRise.csproj
@@ -19,6 +19,8 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Avalonia.ReactiveUI"/>
+    <!-- controls packages -->
+    <PackageReference Include="Avalonia.Controls.DataGrid"/>
 
     <PackageReference Include="Microsoft.Extensions.Hosting"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" />

--- a/GitRise/GitRise.csproj
+++ b/GitRise/GitRise.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Avalonia.ReactiveUI"/>
 
     <PackageReference Include="Microsoft.Extensions.Hosting"/>
     <PackageReference Include="Microsoft.Extensions.Configuration" />

--- a/GitRise/MainWindow.axaml
+++ b/GitRise/MainWindow.axaml
@@ -10,5 +10,8 @@
         x:DataType="vm:MainWindowViewModel"
 
         Title="GitRise">
-    Welcome to Avalonia!
+  <StackPanel>
+    <DataGrid AutoGenerateColumns="True" ItemsSource="{CompiledBinding Commits}" />
+  </StackPanel>
+
 </Window>

--- a/GitRise/MainWindow.axaml
+++ b/GitRise/MainWindow.axaml
@@ -2,8 +2,13 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:GitRise"
+
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+
         x:Class="GitRise.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
+
         Title="GitRise">
     Welcome to Avalonia!
 </Window>

--- a/GitRise/MainWindow.axaml.cs
+++ b/GitRise/MainWindow.axaml.cs
@@ -1,8 +1,9 @@
 using Avalonia.Controls;
+using Avalonia.ReactiveUI;
 
 namespace GitRise;
 
-public partial class MainWindow : Window
+public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 {
     public MainWindow()
     {

--- a/GitRise/MainWindow.axaml.cs
+++ b/GitRise/MainWindow.axaml.cs
@@ -5,8 +5,10 @@ namespace GitRise;
 
 public partial class MainWindow : ReactiveWindow<MainWindowViewModel>
 {
-    public MainWindow()
+    public MainWindow(MainWindowViewModel viewModel)
     {
         InitializeComponent();
+
+        DataContext = viewModel;
     }
 }

--- a/GitRise/MainWindowViewModel.cs
+++ b/GitRise/MainWindowViewModel.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using GitRise.Models;
+using ReactiveUI;
+
+namespace GitRise;
+
+public class MainWindowViewModel : ViewModelBase, IActivatableViewModel
+{
+    public MainWindowViewModel() {}
+
+    #region IActivatableViewModel
+    public ViewModelActivator Activator { get; } = new();
+    #endregion
+}

--- a/GitRise/MainWindowViewModel.cs
+++ b/GitRise/MainWindowViewModel.cs
@@ -10,7 +10,41 @@ namespace GitRise;
 
 public class MainWindowViewModel : ViewModelBase, IActivatableViewModel
 {
-    public MainWindowViewModel() {}
+    public MainWindowViewModel()
+    {
+        RefreshCommits = ReactiveCommand.CreateFromTask(async _ =>
+        {
+            Commits.Clear();
+
+            // dummy data, in fact valid commits from GitConfigurationProvider
+            Commits.Add(new("ad54ae7", "repo: initialize"));
+            Commits.Add(new("9ca189e", "feat: add initial documentation (feat/documentation) [#1]"));
+            Commits.Add(new("882a2bc", "feat: add solution and build configuration files (feat/build-files) [#2]"));
+            Commits.Add(new("f4f867d", "feat: add project files (feat/projects) [#3]"));
+            Commits.Add(new("7833026", "feat: implement initial functionality and test program (feat/initial-implementation) [#4]"));
+            Commits.Add(new("4dd3e2a", "feat(ci): implement GitHub Action workflows (feat/gha-ci-workflows) [#5]"));
+            Commits.Add(new("ffdada2", "refactor: allow optional git configuration (refactor/optional-configuration) [#6]"));
+            Commits.Add(new("b43b6b7", "feat: implement GitConfigurationProvider constructor taking LibGit2Sharp.Configuration (feat/provider-ctor-with-repo-config) [#7]"));
+            Commits.Add(new("bb7d4a3", "feat: extend GitConfigurationProvider API with factory method taking repo/global/xdg/system configuration paths (feat/config-path) [#8]"));
+            Commits.Add(new("fa4b7c0", "feat: extend GitConfigurationProvider API with factory method taking a Repository instance (feat/config-from-repo) [#9]"));
+            Commits.Add(new("3a67b56", "feat: implement initial support for reloading the configuration on change (feat/reload-config) [#10]") );  Commits.Add(new("e824400", "feat: implemented GitConfigurationWatcher as CLI tool for watching the configuration refresh (feature/watcher-tool) [#11]"));
+            Commits.Add(new("bc4a713", "feat: implement Avalonia app displaying command alias from the git configuration (feature/viewer-tool-avalonia) [#12]"));
+            Commits.Add(new("0f91fda", "feat: implement unit tests and enable them in CI (feat/unit-tests) [#13]"));
+            Commits.Add(new("6fc98b1", "refactor: unit tests modify the global configuration (refactor/unit-tests) [#14]"));
+            Commits.Add(new("079b2a7", "build: switch unit tests to Xunit.v3 (build/xunit-v3) [#15]"));
+        });
+
+        this.WhenActivated(disposable =>
+        {
+            RefreshCommits.Execute().Subscribe().DisposeWith(disposable);
+        });
+
+        RefreshCommits.Execute();
+    }
+
+    public ReactiveCommand<Unit, Unit> RefreshCommits { get; }
+
+    public ObservableCollection<Commit> Commits { get; } = new();
 
     #region IActivatableViewModel
     public ViewModelActivator Activator { get; } = new();

--- a/GitRise/Models/Commit.cs
+++ b/GitRise/Models/Commit.cs
@@ -1,0 +1,3 @@
+namespace GitRise.Models;
+
+public record class Commit(string Sha, string Title);

--- a/GitRise/Program.cs
+++ b/GitRise/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using Avalonia;
+using Avalonia.ReactiveUI;
 
 namespace GitRise;
 
@@ -9,13 +10,14 @@ class Program
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args) => BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
 
     // Avalonia configuration, don't remove; also used by visual designer.
-    public static AppBuilder BuildAvaloniaApp() => AppBuilder
-        .Configure<App>()
-        .UsePlatformDetect()
-        .WithInterFont()
-        .LogToTrace();
+    public static AppBuilder BuildAvaloniaApp() =>
+        AppBuilder //
+            .Configure<App>()
+            .UsePlatformDetect()
+            .WithInterFont()
+            .LogToTrace()
+            .UseReactiveUI();
 }

--- a/GitRise/ViewModelBase.cs
+++ b/GitRise/ViewModelBase.cs
@@ -1,0 +1,5 @@
+using ReactiveUI;
+
+namespace GitRise;
+
+public abstract class ViewModelBase : ReactiveObject { }


### PR DESCRIPTION
- **build: add package reference to Avalonia.ReactiveUI**
  

- **build: add package reference to Avalonia.Controls.DataGrid**
  

- **feat(GitRise): set up Avalonia App to use ReactiveUI**
  

- **feat(GitRise): add Avalonia.Controls.DataGrid stylesheet**
  for Fluent theme
  

- **feat(GitRise): define abstract class ViewModelBase**
  inherits from `ReactiveObject`
  

- **feat(GitRise): define class MainWindowViewModel**
  

- **feat(GitRise): host MainWindowViewModel as transient service**
  

- **feat(GitRise): reference MainWindowViewModel in MainWindow UI**
  

- **refactor(GitRise): inherit MainWindow from `ReactiveWindow<MainWindowViewModel>` instead of `Window`**
  

- **feat(GitRise): assign dependency-injected MainWindowViewModel as MainWindow's DataContext**
  

- **feat(GitRise): define record class Commit**
  temporary mockup placeholder for actual commit data
  

- **feat(GitRise): add observable Commits to MainWindowViewModel**
  

- **feat(GitRise): add GridView binding to MainWindowViewModel.Commits to MainWindow UI**
  